### PR TITLE
Zoom to element bounds

### DIFF
--- a/lib/models/geographic_geometries.dart
+++ b/lib/models/geographic_geometries.dart
@@ -11,6 +11,8 @@ import 'package:vector_math/vector_math_64.dart';
 
 abstract class GeographicGeometry {
   LatLng get center;
+
+  LatLngBounds get bounds;
 }
 
 /// A simple node with latitude and longitude coordinates.
@@ -21,6 +23,9 @@ class GeographicPoint implements GeographicGeometry {
   final LatLng center;
 
   const GeographicPoint(this.center);
+
+  @override
+  LatLngBounds get bounds => LatLngBounds.fromPoints([center]);
 }
 
 /// A list of coordinates that build a connection of multiple lines.
@@ -60,6 +65,9 @@ class GeographicPolyline implements GeographicGeometry {
     return _distance.offset(lowerPoint, offset, bearing);
   }
 
+  @override
+  LatLngBounds get bounds => LatLngBounds.fromPoints(path);
+
   bool get isClosed => path.length > 2 && path.first == path.last;
 }
 
@@ -80,7 +88,8 @@ class GeographicPolygon implements GeographicGeometry {
     );
   }
 
-  LatLngBounds get boundingBox => LatLngBounds.fromPoints(outerShape.path);
+  @override
+  LatLngBounds get bounds => outerShape.bounds;
 
   @override
   LatLng get center => boundingBox.center;
@@ -259,12 +268,13 @@ class GeographicMultipolygon implements GeographicGeometry {
 
   const GeographicMultipolygon(this.polygons);
 
-  LatLngBounds get boundingBox {
+  @override
+  LatLngBounds get bounds {
     return LatLngBounds.fromPoints(
       polygons.expand((polygon) => polygon.outerShape.path).toList()
     );
   }
 
   @override
-  LatLng get center => boundingBox.center;
+  LatLng get center => bounds.center;
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -396,7 +396,7 @@ class _HomeScreenContentState extends State<_HomeScreenContent> with TickerProvi
       ticker: this,
       // use bounds method because the normal move to doesn't support padding
       // the benefit of this approach is, that it will always try to zoom in on the marker as much as possible
-      bounds: LatLngBounds.fromPoints([geometricOSMElement.geometry.center]),
+      bounds: geometricOSMElement.geometry.bounds,
       // calculate padding based on question dialog max height
       padding: EdgeInsets.only(
         // add hardcoded marker height for now so it is centered between the top and bottom of the marker


### PR DESCRIPTION
For me it is definitely an improvement to zoom to the bounds of the selected elements so always the entire element is visible.

However one case feels a bit awkward to me. When I unselect a marker which then becomes hidden because another element occupies this space:
[screenrecord.webm](https://user-images.githubusercontent.com/13716661/190429449-300f7e42-1fd0-4511-b113-e380e465f34f.webm)

As an idea: Instead of greying out unselected markers we could simply minimize them. This way the above case should feel less strange.
