### PR TITLE
Improve polygon center calculation

### DIFF
--- a/lib/models/geographic_geometries.dart
+++ b/lib/models/geographic_geometries.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:polylabel/polylabel.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 
@@ -83,7 +84,20 @@ class GeographicPolygon implements GeographicGeometry {
   LatLngBounds get boundingBox => LatLngBounds.fromPoints(outerShape.path);
 
   @override
-  LatLng get center => boundingBox.center;
+  LatLng get center {
+    const projection = SphericalMercator();
+
+    final polygon = [
+      outerShape.path.map(projection.project).toList(),
+      ...innerShapes.map(
+        (polyline) => polyline.path.map(projection.project).toList()
+      ),
+    ];
+
+    final result = polylabel(polygon, precision: 7);
+    final point = CustomPoint(result.point.x, result.point.y);
+    return projection.unproject(point);
+  }
 
   /// Returns true when this polygon has any holes.
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -653,7 +653,7 @@ packages:
     source: hosted
     version: "2.1.2"
   polylabel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: polylabel
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   geolocator: ^9.0.1
   latlong2: ^0.8.0
   vector_math: ^2.1.1
+  polylabel: ^1.0.1
   supercluster: ^0.1.0
   animated_location_indicator:
     git:


### PR DESCRIPTION
Turns out calculating a good visual center point for a polygon is actually not-trivial at all.
Instead of re-inventing the wheel the mapbox polylabel algorithm/package is used which is probably the most common solution these days (also used by flutter map)