### PR TITLE
Improve zoom to bounds

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -414,8 +414,7 @@ class _HomeScreenContentState extends State<_HomeScreenContent> with TickerProvi
       bounds: geometricOSMElement.geometry.bounds,
       // calculate padding based on question dialog max height
       padding: EdgeInsets.only(
-        // add hardcoded marker height for now so it is centered between the top and bottom of the marker
-        top: mediaQuery.padding.top + 60,
+        top: mediaQuery.padding.top,
         bottom: mediaQuery.size.height * _HomeScreenContent.questionDialogMaxHeightFactor
       ),
       // zoom in on 20 or more if the current zoom level is above 20

--- a/lib/utils/map_utils.dart
+++ b/lib/utils/map_utils.dart
@@ -62,16 +62,16 @@ extension AnimationUtils on MapController {
       bounds,
       options: FitBoundsOptions(
         maxZoom: maxZoom,
-        padding: padding
+        padding: padding,
+        // round zoom level so zoom will always stick to integer levels
+        forceIntegerZoomLevel: true,
       )
     );
 
     animateTo(
       ticker: ticker,
       location: centerZoom.center,
-      // round zoom level so zoom will always stick to integer levels
-      // floor so the bounds are always visible
-      zoom: centerZoom.zoom.floorToDouble()
+      zoom: centerZoom.zoom,
     );
   }
 }

--- a/lib/widgets/map_overlay/compass_button.dart
+++ b/lib/widgets/map_overlay/compass_button.dart
@@ -1,10 +1,11 @@
 import 'dart:math';
 import 'package:community_material_icon/community_material_icon.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 /// The rotation is expected in clockwise radians if not otherwise specified by the [isDegree] parameter.
-class CompassButton extends AnimatedWidget {
+class CompassButton extends StatelessWidget {
+  final double rotation;
+
   final void Function() onPressed;
 
   /// Whether the angle unit supplied by the [rotation] is in degrees or radians.
@@ -13,16 +14,14 @@ class CompassButton extends AnimatedWidget {
   static const _piFraction = pi / 180;
 
   const CompassButton({
-    required ValueListenable<double> rotation,
+    required this.rotation,
     required this.onPressed,
     this.isDegree = false,
     Key? key
-  }) : super(listenable: rotation, key: key);
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final rotation = (listenable as ValueListenable<double>).value;
-
     return FloatingActionButton.small(
       heroTag: null,
       onPressed: onPressed,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -284,9 +284,11 @@ packages:
   flutter_map:
     dependency: "direct main"
     description:
-      name: flutter_map
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: fb3f27066be4900f291adaef39fcf665c9c0090d
+      resolved-ref: fb3f27066be4900f291adaef39fcf665c9c0090d
+      url: "https://github.com/fleaflet/flutter_map.git"
+    source: git
     version: "3.0.0"
   flutter_markdown:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,16 +41,18 @@ dependencies:
   nvbw_open_data:
     path: ./dependencies/nvbw_open_data
 
+dependency_overrides:
+  flutter_map:
+    git:
+      url: https://github.com/fleaflet/flutter_map.git
+      ref: fb3f27066be4900f291adaef39fcf665c9c0090d
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_launcher_icons: ^0.10.0
   flutter_lints: ^2.0.0
-  # Required since the latest release is not compatible with dart v2.17
   nock: ^1.2.1
-  #  git:
-  #    url: https://github.com/cah4a/dart_nock.git
-  #    ref: 7643ccb71b1340e81d6291028d0a7eae9da45bb3
   build_runner: ^2.1.7
   build_version: ^2.0.0
 


### PR DESCRIPTION
Previously the zoom to bounds was not centered correctly, because the zoom value was rounded after the calculation of the new map center point.

Additionally this PR fixes an exception that occurred when tapping a marker while the map was rotated.