### PR TITLE
Resolve test workflow run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,14 +34,9 @@ jobs:
       uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 
-    - name: Build OSM website Docker Image
+    - name: Build and start OSM website Docker-Compose
       run: |
-        docker-compose build
-      working-directory: ./osm-website
-
-    - name: Start OSM website Docker-Compose
-      run: |
-        docker-compose up -d
+        docker-compose up -d --build
         sleep 15 # let the DB warm up a little
       working-directory: ./osm-website
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,7 @@ jobs:
         touch config/settings.local.yml
       working-directory: ./osm-website
 
-    # Cache docker build
-    - name: Get cached Docker build
-      uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
-    - name: Build and start OSM website Docker-Compose
+    - name: Build and start OSM website docker
       run: |
         docker-compose up -d --build
         sleep 15 # let the DB warm up a little


### PR DESCRIPTION
Currently the test workflow fails due to out of disk space. This is likely caused by the docker caching.