### PR TITLE
Fix typo in Treppenlift question

### DIFF
--- a/assets/datasets/question_catalog.json
+++ b/assets/datasets/question_catalog.json
@@ -1589,7 +1589,7 @@
       "question": {
          "id": 2090,
          "name": "Treppenlift",
-         "text": "Gibt es an der Treppen einen Treppenlift für Rollstuhlfahrende?",
+         "text": "Gibt es an der Treppe einen Treppenlift für Rollstuhlfahrende?",
          "image": [
             "assets/images/questions/2090a.jpg"
          ]


### PR DESCRIPTION
The question for Treppenlifte says "Gibt es an der Treppen einen Treppenlift für Rollstuhlfahrende?". There is an n too much with this PR removes.