### PR TITLE
Sign fdroid build with apksigner

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -90,7 +90,7 @@ jobs:
         run: >-
           $ANDROID_SDK_ROOT/build-tools/33.0.1/apksigner sign
           --ks-key-alias ${{ secrets.ANDROID_KEY_ALIAS }}
-          --ks-pass ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          --ks-pass pass:"${{ secrets.ANDROID_KEYSTORE_PASSWORD }}"
           --ks key.jks
           build/app/outputs/flutter-apk/app-release.apk
 

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -84,6 +84,16 @@ jobs:
           --dart-define=THUNDERFOREST_API_KEY=${{ secrets.THUNDERFOREST_API_KEY }}
           --dart-define=IS_RELEASE=true
 
+      # Required because F-Droid signs its apk with apksigner which produces a slightly different output than gradle signingConfig
+      # see: https://f-droid.org/docs/Reproducible_Builds/#reproducible-signatures
+      - name: Sign with apksigner
+        run: >-
+          $ANDROID_SDK_ROOT/build-tools/33.0.1/apksigner sign
+          --ks-key-alias ${{ secrets.ANDROID_KEY_ALIAS }}
+          --ks-pass ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          --ks key.jks
+          build/app/outputs/flutter-apk/app-release.apk
+
       - name: Upload F-Droid APK artifact
         uses: actions/upload-artifact@v3
         with:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip


### PR DESCRIPTION
Tries to fix `ERROR: APK Signature Scheme v2 signer #1: APK integrity check failed. CHUNKED_SHA256 digest mismatch.` from the F-Droid build pipeline.