### PR TITLE
Don't ask questions for forbidden steps and paths

### DIFF
--- a/assets/datasets/question_catalog.json
+++ b/assets/datasets/question_catalog.json
@@ -1538,12 +1538,11 @@
                "highway": "footway",
                "footway": [false, "sidewalk"],
                "surface": false,
-               "indoor": ["no", false],
-               "access": [
-                  "yes",
-                  "customers",
-                  false
-               ]
+               "indoor": ["no", false]
+            },
+            "!osm_tags": {
+               "access": ["no","private"],
+               "foot": ["no", "private"]
             },
             "osm_element": [
                "OpenWay",
@@ -1555,12 +1554,11 @@
                "highway": ["path", "cycleway"],
                "foot": ["yes", "designated"],
                "surface": false,
-               "indoor": ["no", false],
-               "access": [
-                  "yes",
-                  "customers",
-                  false
-               ]
+               "indoor": ["no", false]
+            },
+            "!osm_tags": {
+               "access": ["no","private"],
+               "foot": ["no", "private"]
             },
             "osm_element": [
                "OpenWay",
@@ -1799,12 +1797,11 @@
             "osm_tags": {
                "highway": "steps",
                "wheelchair:lift": false,
-               "conveying": [false, "no"],
-               "access": [
-                  "yes",
-                  "customers",
-                  false
-               ]
+               "conveying": [false, "no"]
+            },
+            "!osm_tags": {
+               "access": ["no","private"],
+               "foot": ["no", "private"]
             },
             "osm_element": "OpenWay"
          }
@@ -2027,12 +2024,11 @@
             "osm_tags": {
                "highway": "steps",
                "conveying": [false, "no"],
-               "step:height": false,
-               "access": [
-                  "yes",
-                  "customers",
-                  false
-               ]
+               "step:height": false
+            },
+            "!osm_tags": {
+               "access": ["no","private"],
+               "foot": ["no", "private"]
             },
             "osm_element": "OpenWay"
          }
@@ -2061,12 +2057,11 @@
             "osm_tags": {
                "highway": "steps",
                "conveying": [false, "no"],
-               "step_count": false,
-               "access": [
-                  "yes",
-                  "customers",
-                  false
-               ]
+               "step_count": false
+            },
+            "!osm_tags": {
+               "access": ["no","private"],
+               "foot": ["no", "private"]
             },
             "osm_element": "OpenWay"
          }
@@ -2137,12 +2132,11 @@
             "osm_tags": {
                "highway": "steps",
                "conveying": [false, "no"],
-               "handrail": false,
-               "access": [
-                  "yes",
-                  "customers",
-                  false
-               ]
+               "handrail": false
+            },
+            "!osm_tags": {
+               "access": ["no","private"],
+               "foot": ["no", "private"]
             }
          }
       ]

--- a/assets/datasets/question_catalog.json
+++ b/assets/datasets/question_catalog.json
@@ -1538,7 +1538,12 @@
                "highway": "footway",
                "footway": [false, "sidewalk"],
                "surface": false,
-               "indoor": ["no", false]
+               "indoor": ["no", false],
+               "access": [
+                  "yes",
+                  "customers",
+                  false
+               ]
             },
             "osm_element": [
                "OpenWay",
@@ -1550,7 +1555,12 @@
                "highway": ["path", "cycleway"],
                "foot": ["yes", "designated"],
                "surface": false,
-               "indoor": ["no", false]
+               "indoor": ["no", false],
+               "access": [
+                  "yes",
+                  "customers",
+                  false
+               ]
             },
             "osm_element": [
                "OpenWay",
@@ -1789,7 +1799,12 @@
             "osm_tags": {
                "highway": "steps",
                "wheelchair:lift": false,
-               "conveying": [false, "no"]
+               "conveying": [false, "no"],
+               "access": [
+                  "yes",
+                  "customers",
+                  false
+               ]
             },
             "osm_element": "OpenWay"
          }
@@ -2012,7 +2027,12 @@
             "osm_tags": {
                "highway": "steps",
                "conveying": [false, "no"],
-               "step:height": false
+               "step:height": false,
+               "access": [
+                  "yes",
+                  "customers",
+                  false
+               ]
             },
             "osm_element": "OpenWay"
          }
@@ -2041,7 +2061,12 @@
             "osm_tags": {
                "highway": "steps",
                "conveying": [false, "no"],
-               "step_count": false
+               "step_count": false,
+               "access": [
+                  "yes",
+                  "customers",
+                  false
+               ]
             },
             "osm_element": "OpenWay"
          }
@@ -2112,7 +2137,12 @@
             "osm_tags": {
                "highway": "steps",
                "conveying": [false, "no"],
-               "handrail": false
+               "handrail": false,
+               "access": [
+                  "yes",
+                  "customers",
+                  false
+               ]
             }
          }
       ]


### PR DESCRIPTION
fixes #176

A bit of a "hack", it does technically not check if access is "no" or "private", but the checks check if access is either "yes", "customers" or not set. I think that every case where access is explicitly set but not yes or customers is a case where access is not allowed for the average person.

I added the conditions to all questions that are asked "out of the blue". So e.g. the question that asks for a handrail is asked more or less as soon as something is steps, so I placed the access filter there. In contrast, the question if the handrail has tactical writing would only be asked if a handrail is already in the data, so we would never get there by open stop alone, so to keep the file small I did not place the access filter there.