### PR TITLE
Add additional condition for announcements

### DIFF
--- a/assets/datasets/question_catalog.json
+++ b/assets/datasets/question_catalog.json
@@ -675,6 +675,19 @@
                   }
                }
             ]
+         },
+         {
+            "osm_element": [
+               "ClosedWay",
+               "Relation"
+            ],
+            "osm_tags": {
+               "public_transport": "platform",
+               "railway": "platform",
+               "bus": [false, "no"],
+               "tram": [false, "no"],
+               "announcement": false
+            }
          }
       ]
    },


### PR DESCRIPTION
Currently we are not asking announcements for platforms that do not have a `train=yes` tag like: https://www.openstreetmap.org/way/220720360 We do this, because we do not want to ask this question for tram platforms. If this tag is missing tram platforms are indistinguishable from train platforms because the `railway` tag doesn't differentiate between them.
So asking this question simply if `railway=platform` is set would show this question for a lot of tram stops like: https://www.openstreetmap.org/way/217791160

As a compromise we could only ask this question for `railway=platform` if it is mapped as an area, because it is more likely to be a platform for trains then.