### PR TITLE
Change any OSM length units from cm to m

### DIFF
--- a/assets/datasets/question_catalog.json
+++ b/assets/datasets/question_catalog.json
@@ -798,7 +798,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "height": ["CONCAT", "$input", " cm"]
+            "height": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -830,13 +836,13 @@
          "type": "Number",
          "input": {
             "placeholder": "Plattform-Breite",
-            "decimals": 0,
-            "min": 30,
-            "max": 1500,
-            "unit": "Centimeter"
+            "decimals": 2,
+            "min": 0,
+            "max": 15,
+            "unit": "Meter"
          },
          "constructor": {
-            "width": ["CONCAT", "$input", " cm"]
+            "width": ["$input"]
          }
       },
       "conditions": [
@@ -954,7 +960,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "wheelchair:portable_ramp:length": ["CONCAT", "$input", " cm"]
+            "wheelchair:portable_ramp:length": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1058,7 +1070,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "wheelchair:portable_lift:length": ["CONCAT", "$input", " cm"]
+            "wheelchair:portable_lift:length": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1440,7 +1458,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "width": ["CONCAT", "$input", " cm"]
+            "width": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1670,7 +1694,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "maxwidth:physical": ["CONCAT", "$input", " cm"]
+            "maxwidth:physical": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1707,7 +1737,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "opening": ["CONCAT", "$input", " cm"]
+            "opening": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1744,7 +1780,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "spacing": ["CONCAT", "$input", " cm"]
+            "spacing": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1815,7 +1857,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "wheelchair:lift:length": ["CONCAT", "$input", " cm"]
+            "wheelchair:lift:length": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1847,7 +1895,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "length": ["CONCAT", "$input", " cm"]
+            "length": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1880,7 +1934,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "wheelchair:lift:width": ["CONCAT", "$input", " cm"]
+            "wheelchair:lift:width": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -1912,7 +1972,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "width": ["CONCAT", "$input", " cm"]
+            "width": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [
@@ -2004,7 +2070,13 @@
             "unit": "Centimeter"
          },
          "constructor": {
-            "step:height": ["CONCAT", "$input", " cm"]
+            "step:height": [
+               "REPLACE", "/\\.?0{1,2}$/", "", [
+                  "INSERT", ".", "-2", [
+                     "PAD", "0", "3", "$input"
+                  ]
+               ]
+            ]
          }
       },
       "conditions": [

--- a/docs/QUESTION_CATALOG.md
+++ b/docs/QUESTION_CATALOG.md
@@ -391,6 +391,42 @@ The example will write the three tags *bus*, *tram* & *train*. For unselected op
 }
 ```
 
+#### Using expressions to convert centimeters to meters
+The example makes use of the 3 expressions PAD, INSERT and REPLACE to convert from centimeters to meters. The REPLACE expression is only used to remove any pending zeros (and potentially the decimal point). Note that this expression combination only works for positive integers (not for negative or decimal numbers) and does a conversion by exactly two decimal places to the left.
+
+**Explanation:** The expressions evaluate from the inner most to the outer most as shown in the table below.
+
+| $input | PAD   | INSERT | REPLACE |
+| ------ | ----- | ------ | ------- |
+| 1      | 001   | 0.01   | 0.01    |
+| 1000   | 1000  | 10.00  | 10      |
+| 12     | 012   | 0.12   | 0.12    |
+| 0      | 000   | 0.00   | 0       |
+| 102    | 102   | 1.02   | 1.02    |
+| 120    | 120   | 1.20   | 1.2     |
+
+
+```jsonc
+"answer": {
+    "type": "Number",
+    "input": {
+      "placeholder": "Step height",
+      "decimals": 0,
+      "min": 0,
+      "max": 40,
+      "unit": "Centimeter"
+    },
+    "constructor": {
+      "height": [
+          "REPLACE", "/\\.?0{1,2}$/", "", [
+            "INSERT", ".", "-2", [
+                "PAD", "0", "3", "$input"
+            ]
+          ]
+      ]
+    }
+}
+```
 
 
 ## The `conditions` part


### PR DESCRIPTION
Resolves https://github.com/OPENER-next/OpenStop/issues/128


Explanation:

```
Inputs | PAD  | INSERT | REPLACE
1      > 001  > 0.01   > 0.01
1000   > 1000 > 10.00  > 10
12     > 012  > 0.12   > 0.12
0      > 000  > 0.00   > 0
102    > 102  > 1.02   > 1.02
120    > 120  > 1.20   > 1.2

```
Note:

- This expression combination only works for positive integers (not for negative or decimal numbers) and does a conversion by exactly two decimal places to the left.
- This PR changes the platform width unit from centimeters to meters, mainly because it seems more reasonable. Counter argument to do this, could be that so far all length units use centimeter so users could expect centimeters after all. However the min/max restrictions should at least prevent wrong input values.