### PR TITLE
Simplify changeset comment

### DIFF
--- a/test/osm_upload_api_test.dart
+++ b/test/osm_upload_api_test.dart
@@ -37,7 +37,7 @@ void main() async {
       name: 'Stop1'
     ),
     Stop(
-      location: LatLng(10.00001, 20.00001),
+      location: LatLng(10.00002, 20.00002),
       name: 'Stop2'
     )
   ], LatLng(10.00001, 20.00001), 200);
@@ -48,11 +48,11 @@ void main() async {
       name: 'Stop1'
     ),
     Stop(
-      location: LatLng(10.00001, 20.00001),
+      location: LatLng(10.00002, 20.00002),
       name: 'Stop2'
     ),
     Stop(
-      location: LatLng(10.00001, 20.00001),
+      location: LatLng(10.00003, 20.00003),
       name: 'Stop2'
     )
   ], LatLng(10.00001, 20.00001), 200);

--- a/test/osm_upload_api_test.dart
+++ b/test/osm_upload_api_test.dart
@@ -53,7 +53,7 @@ void main() async {
     ),
     Stop(
       location: LatLng(10.00001, 20.00001),
-      name: 'Stop3'
+      name: 'Stop2'
     )
   ], LatLng(10.00001, 20.00001), 200);
 
@@ -268,7 +268,7 @@ void main() async {
       'created_by': uploadApi02.changesetCreatedBy,
       'locale': uploadApi02.changesetLocale,
       'source': uploadApi02.changesetSource,
-      'comment': 'Details zu MapFeature3, MapFeature1 und MapFeature2 im Haltestellenbereich Stop1 und Stop2 hinzugefügt.',
+      'comment': 'Details zu MapFeature3, MapFeature1 und MapFeature2 im Haltestellenbereich Stop1 hinzugefügt.',
     })));
 
     // update way for triple stop area
@@ -294,7 +294,7 @@ void main() async {
       'created_by': uploadApi03.changesetCreatedBy,
       'locale': uploadApi03.changesetLocale,
       'source': uploadApi03.changesetSource,
-      'comment': 'Details zu MapFeature3, MapFeature1 und MapFeature2 im Haltestellenbereich Stop1, Stop2 und Stop3 hinzugefügt.',
+      'comment': 'Details zu MapFeature3, MapFeature1 und MapFeature2 im Haltestellenbereich Stop2 hinzugefügt.',
     })));
 
     // check if no additional changeset was created by comparing the amount of changesets each query returned


### PR DESCRIPTION
Previously the changeset comment contained all platform names. Now only the most popular name is included.

This was especially annoying for train stations, because every single platform name was included in the comment, while now only one will be shown.