### PR TITLE
Remove obsolete DELFI id from catalog

### DIFF
--- a/assets/datasets/question_catalog.json
+++ b/assets/datasets/question_catalog.json
@@ -1,7 +1,6 @@
 [
    {
       "question": {
-         "id": 1021,
          "name": "Betreiber",
          "text": "Welches Verkehrsunternehmen betreibt diese Einrichtung?",
          "description": "Bei Verkaufsstellen handelt es sich um Einrichtungen, die Fahrkarten verkaufen (z.B. offizielle Vertriebsstellen der Verkehrsunternehmen oder des Verbundgebietes). Die Verkaufsstellen sind i.d.R. mit einem Erkennungszeichen (Tafel, Wimpel, Aufkleber, etc.) ausgestattet. Informationsstellen dienen dazu, sich über Reiserouten etc. zu informieren."
@@ -88,7 +87,6 @@
    },
    {
       "question": {
-         "id": 1022,
          "name": "Rollstuhlgerecht",
          "text": "Ist die Fahrkartenverkaufsstelle rollstuhlgerecht?",
          "description": "Rollstuhlgerecht bedeutet, die Fahrkartenverkaufsstelle ist stufenfrei erreichbar und die Zugänge haben eine ausreichende Breite (≥90cm)."
@@ -120,7 +118,6 @@
    },
    {
       "question": {
-         "id": 1032,
          "name": "Rollstuhlgerecht",
          "text": "Ist die Informationsstelle rollstuhlgerecht?",
          "description": "Rollstuhlgerecht bedeutet, die Informationsstelle ist stufenfrei erreichbar und die Zugänge haben eine ausreichende Breite (≥90cm)."
@@ -153,7 +150,6 @@
    },
    {
       "question": {
-         "id": 1051,
          "name": "Parkplatz-Art",
          "text": "Um welche Art von Parkplatz handelt es sich?"
       },
@@ -206,7 +202,6 @@
    },
    {
       "question": {
-         "id": 1051,
          "name": "Behindertenparkplätze",
          "text": "Gibt es gesonderte Parkplätze für behinderte Personen?",
          "image": [
@@ -247,7 +242,6 @@
    },
    {
       "question": {
-         "id": 1051,
          "name": "Behindertenparkplatz-Anzahl",
          "text": "Wie viele Parkplätze für behinderte Personen gibt es?",
          "description": "Behindertenparkplätze sind eigene Parkmöglichkeiten für behinderte Personen und weisen i.d.R. geräumigere Stellplatzmaße auf. Behindertenparkplätze sind durch ein Zusatzschild mit dem Piktogramm eines Rollstuhlfahrers gekennzeichnet. Zusätzlich sind meist Bodenmarkierungen angebracht."
@@ -280,7 +274,6 @@
    },
    {
       "question": {
-         "id": 1052,
          "name": "Park+Ride",
          "text": "Ist dies ein Park+Ride-Parkplatz?",
          "description": "Park+Ride-Anlagen sind Parkplätze mit Anbindung an öffentliche Verkehrsmittel, die es Personen ermöglichen, ihr Fahrzeug zu verlassen und für den Rest der Reise auf öffentliche Verkehrsmittel umzusteigen.",
@@ -320,7 +313,6 @@
    },
    {
       "question": {
-         "id": 1052,
          "name": "Parkplatz-Gebühren",
          "text": "Fallen für das Parken Gebühren an?"
       },
@@ -355,7 +347,6 @@
    },
    {
       "question": {
-         "id": 1071,
          "name": "Toiletten-Zugänglichkeit",
          "text": "Für wen sind die Toiletten zugänglich?",
          "image": [
@@ -403,7 +394,6 @@
    },
    {
       "question": {
-         "id": 1075,
          "name": "Toiletten-Gebühren",
          "text": "Ist die Nutzung der Toilette kostenpflichtig?"
       },
@@ -437,7 +427,6 @@
    },
    {
       "question": {
-         "id": 1120,
          "name": "Sitzplätze",
          "text": "Gibt es an der Haltestelle Sitzplätze?",
          "image": [
@@ -477,7 +466,6 @@
    },
    {
       "question": {
-         "id": 1120,
          "name": "Überdachter Wartebereich",
          "text": "Gibt es an der Haltestelle einen überdachten Wartebereich?",
          "image": [
@@ -519,7 +507,6 @@
    },
    {
       "question": {
-         "id": 1130,
          "name": "Fahrplan-Anzeige",
          "text": "Gibt es eine stationsweite Fahrplan-Anzeige?",
          "description": "Fahrplan-Anzeigen geben einen Überblick aller Fahrten an der gesamten Station. Dynamische Anzeigen informieren über aktuelle Fahrplanänderungen wie Verspätungen, Ausfälle oder Gleisänderungen. Statische Anzeigen sind gedruckte Fahrpläne."
@@ -568,7 +555,6 @@
    },
    {
       "question": {
-         "id": 1131,
          "name": "Akustische Ausgabe der Fahrplan-Anzeige",
          "text": "Hat die stationsweite Fahrplan-Anzeige eine manuell anforderbare akustische Ausgabe?",
          "description": "Fahrplan-Anzeigen geben einen Überblick aller Fahrten an der gesamten Station. Einige Fahrplan-Anzeigen bieten die Möglichkeit, bei Bedarf (z.B. über einen Taster) die angezeigten Informationen akustisch wiederzugeben.",
@@ -606,7 +592,6 @@
    },
    {
       "question": {
-         "id": 1140,
          "name": "Dynamischer Fahrtziel-Anzeiger",
          "text": "Gibt es einen dynamischen Fahrtziel-Anzeiger an der Haltestelle?",
          "description": "Dynamische Fahrtziel-Anzeiger zeigen Echtzeit-Informationen über das Ziel ein- bzw. abfahrender Züge/Busse an einem Bahn-/Bussteig an.",
@@ -649,7 +634,6 @@
    },
    {
       "question": {
-         "id": 1141,
          "name": "Akustische Ausgabe des Fahrtziel-Anzeigers",
          "text": "Hat der dynamische Fahrtziel-Anzeiger an der Haltestelle eine akustische Ausgabe?",
          "description": "Einige Fahrtziel-Anzeiger bieten die Möglichkeit, bei Bedarf (z.B. über einen Taster) die angezeigten Informationen akustisch wiederzugeben.",
@@ -691,7 +675,6 @@
    },
    {
       "question": {
-         "id": 1150,
          "name": "Ansagen",
          "text": "Gibt es Ansagen über Lautsprecher an der Plattform?",
          "description": "Unter Ansagen werden die akustischen Fahrgastinformationen an der Haltestelle verstanden.",
@@ -734,7 +717,6 @@
    },
    {
       "question": {
-         "id": 1170,
          "name": "Haltestellen-Bordstein",
          "text": "Hat die Haltestelle an der Fahrbahnseite einen Bordstein?"
       },
@@ -789,7 +771,6 @@
    },
    {
       "question": {
-         "id": 1170,
          "name": "Bordstein-Art",
          "text": "Welche Art von Bordstein hat die Haltestelle an der Seite, an der das Verkehrsmittel hält?"
       },
@@ -837,7 +818,6 @@
    },
    {
       "question": {
-         "id": 1170,
          "name": "Plattform-Höhe",
          "text": "Wie groß ist der Höhenunterschied zwischen Plattform und Straße bzw. Schienenoberkante?",
          "description": "Wenn diese Höhe innerhalb eines Steiges variiert, ist der typische Wert für die übliche Einstiegsstelle von Rollstuhlfahrenden zu bestimmen."
@@ -878,7 +858,6 @@
    },
    {
       "question": {
-         "id": 1180,
          "name": "Plattform-Breite",
          "text": "Was ist die überwiegende Breite der Plattform?",
          "description": "Die Breite einer Plattform wird quer zur Fahrtrichtung gemessen. Variiert die Breite, ist die anzugeben, die den Großteil der Plattform umfasst. Achtung: Die engste Stelle einer Plattform wird separat erfasst.",
@@ -947,7 +926,6 @@
    },
    {
       "question": {
-         "id": 1200,
          "name": "Anfahrtshilfe",
          "text": "Hat die Haltestelle einen speziellen Bordstein mit Anfahrtshilfe für Busse?",
          "description": "Bordsteine mit Anfahrtshilfe haben eine konkave Rundung zur Straße hin. Diese sorgt für eine Führung der Busreifen beim Anfahren der Haltestelle und ermöglicht so Bussen ein dichtes Heranfahren an die Bordsteinkante.",
@@ -993,7 +971,6 @@
    },
    {
       "question": {
-         "id": 1210,
          "name": "Bewegbare Rampe",
          "text": "Gibt es eine bewegbare Rollstuhl-Rampe?",
          "description": "Bahnsteiggebundene Rampen sind bewegbar und helfen beim Ein- und Ausstieg von Rollstuhlfahrenden zur Überwindung eines Spalts bzw. von Stufen.",
@@ -1035,7 +1012,6 @@
    },
    {
       "question": {
-         "id": 1211,
          "name": "Rampen-Länge",
          "text": "Wie lang ist die bewegbare Rollstuhl-Rampe?",
          "description": "Bahnsteiggebundene Rampen sind bewegbar und helfen beim Ein- und Ausstieg von Rollstuhlfahrenden zur Überwindung eines Spalts bzw. von Stufen.",
@@ -1073,7 +1049,6 @@
    },
    {
       "question": {
-         "id": 1212,
          "name": "Rampen-Tragfähigkeit",
          "text": "Was ist die maximale Tragfähigkeit der bewegbaren Rampe?",
          "description": "Bahnsteiggebundene Rampen sind bewegbar und helfen beim Ein- und Ausstieg von Rollstuhlfahrenden zur Überwindung eines Spalts bzw. von Stufen.",
@@ -1105,7 +1080,6 @@
    },
    {
       "question": {
-         "id": 1220,
          "name": "Bewegbarer Hublift",
          "text": "Gibt es einen bewegbaren Hublift für Rollstuhlfahrende?",
          "description": "Bahnsteiggebundene Hublifte sind bewegbar und helfen beim Ein- und Ausstieg von Rollstuhlfahrenden zur Überwindung eines Spalts bzw. von Stufen.",
@@ -1148,7 +1122,6 @@
    },
    {
       "question": {
-         "id": 1221,
          "name": "Hublift-Stellflächenlänge",
          "text": "Wie lang ist die Stellfläche des bewegbaren Hublifts?",
          "description": "Bahnsteiggebundene Hublifte sind bewegbar und helfen beim Ein- und Ausstieg von Rollstuhlfahrenden zur Überwindung eines Spalts bzw. von Stufen.",
@@ -1187,7 +1160,6 @@
    },
    {
       "question": {
-         "id": 1222,
          "name": "Hublift-Tragfähigkeit",
          "text": "Was ist die maximale Tragfähigkeit der bewegbaren Hublifts?",
          "description": "Bahnsteiggebundene Hublifte sind bewegbar und helfen beim Ein- und Ausstieg von Rollstuhlfahrenden zur Überwindung eines Spalts bzw. von Stufen.",
@@ -1220,7 +1192,6 @@
    },
    {
       "question": {
-         "id": 2032,
          "name": "Tür",
          "text": "Hat dieser Durchgang eine Tür?",
          "description": "Ob ein Durchgang eine Tür hat, ist besonders für Rollstuhlfahrende relevant. Existiert eine Tür, wird die genaue Art nachfolgend abgefragt."
@@ -1294,7 +1265,6 @@
    },
    {
       "question": {
-         "id": 2032,
          "name": "Tür-Art",
          "text": "Welche Art von Tür ist verbaut?"
       },
@@ -1383,7 +1353,6 @@
    },
    {
       "question": {
-         "id": 2033,
          "name": "Tür-Automatik",
          "text": "Kann sich die Tür automatisch öffnen?",
          "description": "Bei der automatischen Öffnung wird die Tür von einer Mechanik geöffnet. Diese kann durch einen Sensor oder Taster ausgelöst werden."
@@ -1459,7 +1428,6 @@
    },
    {
       "question": {
-         "id": 2033,
          "name": "Drehtür-Automatik",
          "text": "Bewegt sich die Drehtür automatisch?",
          "description": "Drehtüren, die sich automatisch drehen, müssen nicht durch eigene Körperkraft bewegt werden."
@@ -1535,7 +1503,6 @@
    },
    {
       "question": {
-         "id": 2033,
          "name": "Tür-Automatik-Art",
          "text": "Wodurch wird die automatische Tür-Öffnung ausgelöst?",
          "description": "Automatik-Türen können sich durch Sensoren bei Annäherung einer Person öffnen oder durch das Betätigen eines Tasters."
@@ -1615,7 +1582,6 @@
    },
    {
       "question": {
-         "id": 2033,
          "name": "Drehtür-Automatik-Art",
          "text": "Wie funktioniert die Automatik der Drehtür?",
          "description": "Automatik-Drehtüren können sich kontinuierlich bewegen oder durch Sensoren bei Annäherung einer Person in Bewegung versetzt werden."
@@ -1699,7 +1665,6 @@
    },
    {
       "question": {
-         "id": 2034,
          "name": "Durchgangsbreite",
          "text": "Wie breit ist der Durchgang?",
          "description": "Die Durchgangsbreite wird erfasst, um sicherzustellen das Rollstühle, Kinderwagen etc. genug Platz haben. Es ist lediglich die nutzbare Türöffnung (Innenmaße der geöffneten Tür) zu messen."
@@ -1777,7 +1742,6 @@
    },
    {
       "question": {
-         "id": 2050,
          "name": "Bodenbeschaffenheit",
          "text": "Wie ist der Boden beschaffen?",
          "description": "Besteht die Oberfläche aus Schotter, Sand, Gras oder einem vergleichbaren Belag, so handelt es sich um einen unbefestigten Bodenbelag."
@@ -1876,14 +1840,13 @@
                "Node",
                "OpenWay",
                "ClosedWay",
-               "Relation" 
+               "Relation"
             ]
          }
       ]
    },
    {
       "question": {
-         "id": 2070,
          "name": "Bodenindikatoren",
          "text": "Gibt es Bodenindikatoren an der Haltestelle?",
          "description": "Bodenindikatoren sind Bodenelemente im öffentlichen Raum zur Information, Orientierung, Leitung und Warnung sehbehinderter Menschen. Sie stehen in einem hohen taktilen, visuellen und gegebenenfalls akustischen Kontrast zum angrenzenden Bodenbelag.",
@@ -1925,7 +1888,6 @@
    },
    {
       "question": {
-         "id": 2080,
          "name": "Umlaufsperren-Art",
          "text": "Wie ist der Aufbau der Umlaufsperre?"
       },
@@ -1974,7 +1936,6 @@
    },
    {
       "question": {
-         "id": 2081,
          "name": "Umlaufsperren-Durchgangsbreite",
          "text": "Wie groß ist die Durchgangsbreite der Umlaufsperre?",
          "image": [
@@ -2016,7 +1977,6 @@
    },
    {
       "question": {
-         "id": 2081,
          "name": "Umlaufsperren-Zugangsbreite",
          "text": "Wie breit ist der (schmalste) Zugang der Umlaufsperre?",
          "image": [
@@ -2059,7 +2019,6 @@
    },
    {
       "question": {
-         "id": 2081,
          "name": "Umlaufsperren-Abstand",
          "text": "Was ist der (kleinste) Abstand zwischen den Elementen der Umlaufsperre?",
          "image": [
@@ -2102,7 +2061,6 @@
    },
    {
       "question": {
-         "id": 2090,
          "name": "Treppenlift",
          "text": "Gibt es an der Treppe einen Treppenlift für Rollstuhlfahrende?",
          "image": [
@@ -2140,7 +2098,6 @@
    },
    {
       "question": {
-         "id": 2093,
          "name": "Treppenlift-Tiefe",
          "text": "Wie tief ist die Stellfläche des Treppenlifts?",
          "image": [
@@ -2178,7 +2135,6 @@
    },
    {
       "question": {
-         "id": 2093,
          "name": "Fahrstuhl-Tiefe",
          "text": "Wie tief ist die Grundfläche des Fahrstuhls?",
          "image": [
@@ -2217,7 +2173,6 @@
    },
    {
       "question": {
-         "id": 2094,
          "name": "Treppenlift-Breite",
          "text": "Wie breit ist die Stellfläche des Treppenlifts?",
          "image": [
@@ -2255,7 +2210,6 @@
    },
    {
       "question": {
-         "id": 2094,
          "name": "Fahrstuhl-Breite",
          "text": "Wie breit ist die Grundfläche des Fahrstuhls?",
          "image": [
@@ -2357,7 +2311,6 @@
    },
    {
       "question": {
-         "id": 2112,
          "name": "Stufen-Höhe",
          "text": "Wie hoch ist eine einzelne Stufe?"
       },
@@ -2396,7 +2349,6 @@
    },
    {
       "question": {
-         "id": 2113,
          "name": "Stufen-Anzahl",
          "text": "Wie viele Stufen hat die Treppe?"
       },
@@ -2550,7 +2502,6 @@
    },
    {
       "question": {
-         "id": 2134,
          "name": "Rolltreppen-Fahrtdauer",
          "text": "Wie lange dauert die Fahrt mit der Rolltreppe bzw. dem Laufband?",
          "description": "Ein Laufband (auch Rollsteig, Fahrsteig, bewegter oder rollender Bürgersteig genannt) ist ein sich bewegendes Fortbewegungsmittel, welches Personen auf einer horizontalen oder schrägen Ebene transportiert. Eine Rolltreppe ist eine sich bewegende Treppe, um Personen zwischen Stockwerken eines Gebäudes zu transportieren. Die Dauer der Rollentreppen-Fahrt ist relevant für die Berechnung von Umstiegszeiten."

--- a/assets/datasets/question_catalog_schema.json
+++ b/assets/datasets/question_catalog_schema.json
@@ -16,11 +16,6 @@
         "required": [ "name", "text" ],
         "additionalProperties": false,
         "properties": {
-          "id": {
-            "description": "The DELFI id this question is derived from.",
-            "type": "integer",
-            "exclusiveMinimum": 0
-          },
           "name": {
             "description": "A short term describing the content of the answer.",
             "type": "string"

--- a/lib/models/question_catalog/question_definition.dart
+++ b/lib/models/question_catalog/question_definition.dart
@@ -11,8 +11,6 @@ import 'answer_definition.dart';
 class QuestionDefinition {
   final int runtimeId;
 
-  final int? id;
-
   final String name;
 
   final String question;
@@ -34,14 +32,12 @@ class QuestionDefinition {
     required this.isProfessional,
     required this.conditions,
     required this.answer,
-    this.id,
     this.description = '',
     this.images = const []
   });
 
 
   QuestionDefinition.fromJSON(this.runtimeId, Map<String, dynamic> json) :
-    id = json['question']['id'],
     name = json['question']['name'],
     description = json['question']['description'] ?? '',
     images = json['question']['image']?.cast<String>() ?? [],
@@ -56,7 +52,7 @@ class QuestionDefinition {
 
   @override
   String toString() {
-    return 'QuestionDefinition(runtimeId: $runtimeId, id: $id, name: $name, question: $question, description: $description, images: $images, isProfessional: $isProfessional, conditions: $conditions, answer: $answer)';
+    return 'QuestionDefinition(runtimeId: $runtimeId, name: $name, question: $question, description: $description, images: $images, isProfessional: $isProfessional, conditions: $conditions, answer: $answer)';
   }
 
   @override

--- a/test/questionnaire_test.dart
+++ b/test/questionnaire_test.dart
@@ -18,19 +18,19 @@ void main() async {
   );
 
   final dummyCatalog = QuestionCatalog([
-    QuestionDefinition(runtimeId: 0, id: 0, name: 'q1', question: 'q1', isProfessional: false,
+    QuestionDefinition(runtimeId: 0, name: 'q1', question: 'q1', isProfessional: false,
       conditions: [
         ElementCondition([ TagsSubCondition.fromJson({ 'tag_a': false }) ]),
       ],
       answer: stringAnswer,
     ),
-    QuestionDefinition(runtimeId: 1, id: 0, name: 'q2', question: 'q2', isProfessional: false,
+    QuestionDefinition(runtimeId: 1, name: 'q2', question: 'q2', isProfessional: false,
       conditions: [
         ElementCondition([ TagsSubCondition.fromJson({ 'tag_a': '1' }) ]),
       ],
       answer: stringAnswer,
     ),
-    QuestionDefinition(runtimeId: 2, id: 0, name: 'q2', question: 'q2', isProfessional: false,
+    QuestionDefinition(runtimeId: 2, name: 'q2', question: 'q2', isProfessional: false,
       conditions: [
         ElementCondition([ TagsSubCondition.fromJson({ 'tag_a': '2' }) ]),
       ],


### PR DESCRIPTION
The `id` always served as a way to reference a question/osm tags to the original DELFI attribute. Since then it lead to recurring confusions for other developers.

We now have various other places were this reference is depicted.
First and foremost the wiki: https://wiki.openstreetmap.org/wiki/DELFI_Attribute_-_Barrierefreiheit_im_%C3%96ffentlichen_Personenverkehr#Fahrplananzeigetafeln
but soon also in a more machine-readable way here: https://github.com/OPENER-next/tag_condition_map/pull/2