### PR TITLE
Do not ask for crossing:whistle on tram crossings

### DIFF
--- a/assets/question_catalog/definition.json
+++ b/assets/question_catalog/definition.json
@@ -3279,7 +3279,7 @@
       "conditions": [
          {
             "osm_tags": {
-               "railway": ["crossing"],
+               "railway": "crossing",
                "crossing:barrier": "no",
                "crossing:light": "no",
                "crossing:bell": "no",

--- a/assets/question_catalog/definition.json
+++ b/assets/question_catalog/definition.json
@@ -3279,7 +3279,7 @@
       "conditions": [
          {
             "osm_tags": {
-               "railway": ["crossing", "tram_crossing"],
+               "railway": ["crossing"],
                "crossing:barrier": "no",
                "crossing:light": "no",
                "crossing:bell": "no",


### PR DESCRIPTION
This PR removes tram crossings from the crossings for which "Does the train make an acoustic signal when it drives through?" is asked.