### PR TITLE
Fix Location Indicator not being shown

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -132,7 +132,8 @@ class HomeScreen extends View<HomeViewModel> with PromptHandler {
                     builder: (context) {
                       // rebuild location indicator when location access is granted
                       viewModel.userLocationState;
-                      return const AnimatedLocationLayer();
+                      // ignore: prefer_const_constructors
+                      return AnimatedLocationLayer();
                     },
                   ),
                   Observer(


### PR DESCRIPTION
In the current app version the so called Location Indicator does not get rendered, if the apps gets started for the first time or with no location permissions granted.
 
Debugging has revealed that due to `const` before `AnimatedLocationLayer()` in (former) line 135 in lib/screens/home.dart the corresponding didWidgetUpdate method **is not** being called.  That is also the reason why the Location Indicator gets rendered after restarting the app, because the `build` function directly renders the Location Indicator and the not a temporary placeholder (which is "shown" as long as granting permission is pending or no permissions are granted at all).

Remove moving the `const` fixes the problem. Although this solution may not be clean due to a nagging linter. That's why there is also an ignore comment.