### PR TITLE
Prevent web build from failing

### DIFF
--- a/lib/models/answer.dart
+++ b/lib/models/answer.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 
 import 'question_catalog/answer_definition.dart';
@@ -239,7 +238,7 @@ class DurationAnswer extends Answer<DurationAnswerDefinition, Duration> {
 
     // wrap duration parts according to the units present in the output
 
-    const maxInteger = kIsWeb ? 0x20000000000000 : 0x7FFFFFFFFFFFFFFF;
+    final maxInteger = double.maxFinite.toInt();
     var (wrapHours, wrapMinutes, wrapSeconds) = (maxInteger, maxInteger, maxInteger);
 
     if (definition.input.days.output) {

--- a/web/index.html
+++ b/web/index.html
@@ -31,7 +31,7 @@
   <link rel="manifest" href="manifest.json">
   <script>
     // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
+    var serviceWorkerVersion = '{{flutter_service_worker_version}}';
   </script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
@@ -40,7 +40,7 @@
   <script>
     window.addEventListener('load', function(ev) {
       // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
+      _flutter.loader.load({
         serviceWorker: {
           serviceWorkerVersion: serviceWorkerVersion,
         }


### PR DESCRIPTION
This PR changes minor things so that compiling for web doesn't thrown errors or warnings anymore.
The app still doesn't work in the web due to using Isolates: https://docs.flutter.dev/perf/isolates#web-platforms-and-compute