### PR TITLE
Rework animated marker layer

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -164,10 +164,7 @@ class HomeScreen extends View<HomeViewModel> with PromptHandler {
                           viewModel.uploadQueue.length;
                           return OsmElementLayer(
                             elements: viewModel.elements,
-                            currentZoom: viewModel.mapZoomRound,
-                            onOsmElementTap: viewModel.onElementTap,
-                            selectedElement: viewModel.selectedElement,
-                            uploadQueue: viewModel.uploadQueue,
+                          // onSelect: viewModel.onElementTap,
                           );
                         },
                       ),

--- a/lib/widgets/completed_area_layer/completed_area_layer.dart
+++ b/lib/widgets/completed_area_layer/completed_area_layer.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart' hide Path;
 
 import '/widgets/animated_path.dart';
-import '/widgets/loading_area_layer/map_layer.dart';
+import '../map_layer.dart';
 
 /// Layer to highlight completed stop areas.
 

--- a/lib/widgets/loading_area_layer/loading_area_layer.dart
+++ b/lib/widgets/loading_area_layer/loading_area_layer.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
 
-import 'map_layer.dart';
+import '../map_layer.dart';
 import 'ripple_indicator.dart';
 
 /// Layer to show ripple animations for geo circles and automatically remove them when expired.

--- a/lib/widgets/osm_element_layer/osm_element_layer.dart
+++ b/lib/widgets/osm_element_layer/osm_element_layer.dart
@@ -1,43 +1,73 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:animated_marker_layer/animated_marker_layer.dart';
 import 'package:flutter/material.dart';
-import 'package:supercluster/supercluster.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'package:mobx/mobx.dart';
 
-import '/api/app_worker/element_handler.dart';
-import '/l10n/app_localizations.g.dart';
-import '/models/map_features/map_feature_representation.dart';
-import '/widgets/osm_element_layer/osm_element_marker.dart';
+import '../../api/app_worker/element_handler.dart';
+import '../../l10n/app_localizations.g.dart';
+import '../../models/map_features/map_feature_representation.dart';
+import '../map_layer.dart';
+import 'osm_element_marker.dart';
+
+
+class MapFeatureState extends MapFeatureRepresentation {
+  final _active = Observable(false);
+  bool get active => _active.value;
+  set active(bool value) => _active.value = value;
+
+  final _uploadState = Observable<Future<void>?>(null);
+  Future<void>? get uploadState => _uploadState.value;
+  set uploadState(Future<void>? value) => _uploadState.value = value;
+
+  final void Function(MapFeatureState)? onTap;
+  final BoxCollider collider = BoxCollider(60, 60);
+
+  MapFeatureState.fromRepresentation({
+    required MapFeatureRepresentation representation,
+    this.onTap,
+    }) : super(
+      id: representation.id,
+      type: representation.type,
+      geometry: representation.geometry,
+      icon: representation.icon,
+      label: (_, __) => 'TODO',
+      tags: const {},
+    );
+
+}
+
+
+
+
+
+
+
+// Problem:
+// - Minimized marker overlaps non minimized markers
+// only solution is to render them on a totally separate layer OR can sort them? Perhaps I can give a priority property or so
+// - instable dadurch, dass ich am rand welche ausblende wird plötzlich platz für andere marker
+// - instable durch zoomen, weil plötzlich platz für einen vorhergehenden marker wird wodurch allerdings der darauffolgende keinen mehr hat ()
+// - "on add" rendert zunächst element, collision detection hat erst einfluss im nächsten frame
+// - MapLayerPositioned align will be different (bottom vs center)
+
+// Solution:
+// - Minimized marker Overlapp: Second layer mit transform target + follower und minimized marker follown dann ihrem marker?
+
+// sort markers based on distance to one starting marker?
 
 class OsmElementLayer extends StatefulWidget {
   final Stream<ElementUpdate> elements;
 
-  final MapFeatureRepresentation? selectedElement;
-
-  final void Function(MapFeatureRepresentation osmElement)? onOsmElementTap;
-
-  final Map<MapFeatureRepresentation, Future> uploadQueue;
-
-  /// The maximum shift in duration between different markers.
-
-  final Duration durationOffsetRange;
-
-  /// The current zoom level.
-
-  final num currentZoom;
-
-  /// The lowest zoom level on which the layer is still visible.
+  final void Function(MapFeatureRepresentation? element)? onSelect;
 
   final int zoomLowerLimit;
 
   const OsmElementLayer({
     required this.elements,
-    required this.currentZoom,
-    required this.uploadQueue,
-    this.selectedElement,
-    this.onOsmElementTap,
-    this.durationOffsetRange = const Duration(milliseconds: 300),
+    this.onSelect,
     // TODO: currently changes to this won't update the super cluster
     this.zoomLowerLimit = 16,
     super.key,
@@ -47,232 +77,249 @@ class OsmElementLayer extends StatefulWidget {
   State<OsmElementLayer> createState() => _OsmElementLayerState();
 }
 
-class _OsmElementLayerState extends State<OsmElementLayer> {
-  StreamSubscription<ElementUpdate>? _streamSubscription;
+class _OsmElementLayerState extends AddRemovalAnimationBase<OsmElementLayer, MapFeatureState> {
 
-  late final _superCluster = SuperclusterMutable<MapFeatureRepresentation>(
-    getX: (p) => p.geometry.center.longitude,
-    getY: (p) => p.geometry.center.latitude,
-    minZoom: widget.zoomLowerLimit,
-    maxZoom: 20,
-    radius: 120,
-    extent: 512,
-    nodeSize: 64,
-    extractClusterData: (customMapPoint) => _ClusterLeafs([customMapPoint]),
-  );
+  late StreamSubscription _elementsSub;
 
   @override
   void initState() {
     super.initState();
-    _streamSubscription = widget.elements.listen(_handleElementChange);
+    _elementsSub = widget.elements.listen(_handleElementChanges);
   }
 
   @override
   void didUpdateWidget(covariant OsmElementLayer oldWidget) {
     super.didUpdateWidget(oldWidget);
-
     if (widget.elements != oldWidget.elements) {
-      _streamSubscription?.cancel();
-      _streamSubscription = widget.elements.listen(_handleElementChange);
+      _elementsSub.cancel();
+      _elementsSub = widget.elements.listen(_handleElementChanges);
     }
   }
 
-  void _handleElementChange(ElementUpdate change) {
-    setState(() {
-      if (change.action == ElementUpdateAction.clear) {
-        _superCluster.load([]);
-      } else if (change.action == ElementUpdateAction.update) {
-        // _superCluster.containsPoint() will not globally check whether a point
-        // has already been added.
-        // So if the point position has been modified it may not find it.
-        // Therefore use _superCluster.points.contains().
-        if (_superCluster.points.contains(change.element)) {
-          _superCluster.modifyPointData(change.element!, change.element!);
-        } else {
-          _superCluster.add(change.element!);
-        }
-      } else if (change.action == ElementUpdateAction.remove) {
-        _superCluster.remove(change.element!);
-      }
-    });
+  void _handleElementChanges(ElementUpdate change) {
+    if (change.action == ElementUpdateAction.clear) {
+    }
+    else if (change.action == ElementUpdateAction.update) {
+      print("add");
+
+      // TODO: what happens on update? / duplicates?
+      add(MapFeatureState.fromRepresentation(
+        onTap: (element) {
+          runInAction(() => element.active = !element.active);
+          widget.onSelect?.call(element.active
+            ? element
+            : null,
+          );
+        },
+        representation: change.element!
+      ), duration: Duration(seconds: 1));
+    }
+    else if (change.action == ElementUpdateAction.remove) {
+      remove(MapFeatureState.fromRepresentation(
+        representation: change.element!
+      ), duration: Duration(seconds: 1));
+    }
   }
 
-  @override
-  void dispose() {
-    _streamSubscription?.cancel();
-    super.dispose();
-  }
+
+  AppLocalizations get appLocale => AppLocalizations.of(context)!;
 
   @override
   Widget build(BuildContext context) {
-    final visibleMarkers = <AnimatedMarker>[];
-    final suppressedMarkers = <AnimatedMarker>[];
+    return MapLayer(
+      children: getChildren(context).toList(growable: false),
+    );
+  }
 
-    if (widget.currentZoom >= widget.zoomLowerLimit) {
-      final clusters = _superCluster.search(-180, -85, 180, 85, widget.currentZoom.toInt());
-      var activeMarkerFound = false;
+  @override
+  Widget itemBuilder(context, item, animation) {
+    animation = CurvedAnimation(
+      parent: animation,
+      curve: Curves.elasticOut,
+      reverseCurve: Curves.easeOutBack,
+    );
 
-      for (final cluster in clusters) {
-        // get elements from cluster
-        final elements = _elementsFromCluster(cluster).iterator;
-
-        if (widget.selectedElement != null) {
-          while (!activeMarkerFound && elements.moveNext()) {
-            if (widget.selectedElement == elements.current) {
-              visibleMarkers.add(_createMarker(elements.current));
-              activeMarkerFound = true;
-            } else {
-              suppressedMarkers.add(_createMinimizedMarker(elements.current));
-            }
-          }
-          while (elements.moveNext()) {
-            suppressedMarkers.add(_createMinimizedMarker(elements.current));
-          }
-        } else {
-          // loop over elements so that only the first one is a marker and not a placeholder
-          if (elements.moveNext()) {
-            visibleMarkers.add(
-              _createMarker(elements.current),
-            );
-            while (elements.moveNext()) {
-              suppressedMarkers.add(
-                _createMinimizedMarker(elements.current),
-              );
-            }
-          }
-        }
-      }
-    }
-
-    // hide layer when zooming out passing the lower zoom limit
-    return AnimatedSwitcher(
-      // instantly show the animated marker layer since the markers themselves will be animated in
-      duration: Duration.zero,
-      reverseDuration: const Duration(milliseconds: 300),
-      child: widget.currentZoom >= widget.zoomLowerLimit
-          ? Stack(
-              children: [
-                AnimatedMarkerLayer(
-                  markers: suppressedMarkers,
-                ),
-                AnimatedMarkerLayer(
-                  markers: visibleMarkers,
-                ),
-              ],
+    return MapLayerPositioned(
+      key: ValueKey(item),
+      position: item.geometry.center,
+      align: Alignment.bottomCenter,
+      collider: item.collider,
+      child: ValueListenableBuilder(
+        valueListenable: item.collider,
+        builder: (context, collision, child) {
+          return ScaleTransition(
+            scale: animation,
+            alignment: Alignment.bottomCenter,
+            filterQuality: FilterQuality.low,
+            child: AnimatedSwitcher(
+              duration: Duration(milliseconds: 300),
+              transitionBuilder: (child, animation) {
+                if (child is Container) {
+                  return FadeTransition(
+                    opacity: animation,
+                    child: child,
+                  );
+                }
+                else {
+                  return ScaleTransition(
+                    scale: CurvedAnimation(
+                      parent: animation,
+                      curve: Curves.elasticOut,
+                      reverseCurve: Curves.easeOutBack,
+                    ),
+                    alignment: Alignment.bottomCenter,
+                    filterQuality: FilterQuality.low,
+                    child: child,
+                  );
+                }
+              },
+              child: collision
+                ? Container(color: Colors.blue,width: 5, height: 5,)
+                : child
             )
-          : null,
-    );
-  }
-
-  Iterable<MapFeatureRepresentation> _elementsFromCluster(
-    MutableLayerElement<MapFeatureRepresentation> cluster,
-  ) sync* {
-    if (cluster is MutableLayerCluster<MapFeatureRepresentation>) {
-      yield* (cluster.clusterData! as _ClusterLeafs).elements;
-    } else if (cluster is MutableLayerPoint<MapFeatureRepresentation>) {
-      yield cluster.originalPoint;
-    }
-  }
-
-  Duration _getRandomDelay([int? seed]) {
-    if (widget.durationOffsetRange.inMicroseconds == 0) {
-      return Duration.zero;
-    }
-    final randomTimeOffset = Random(seed).nextInt(widget.durationOffsetRange.inMicroseconds);
-    return Duration(microseconds: randomTimeOffset);
-  }
-
-  AnimatedMarker _createMarker(MapFeatureRepresentation element) {
-    // supply id as seed so we get the same delay for both marker types
-    final seed = element.id;
-    return _OsmElementMarker(
-      element: element,
-      animateInDelay: _getRandomDelay(seed),
-      builder: _markerBuilder,
-    );
-  }
-
-  Widget _markerBuilder(BuildContext context, Animation<double> animation, AnimatedMarker marker) {
-    final appLocale = AppLocalizations.of(context)!;
-    marker as _OsmElementMarker;
-    final isActive = widget.selectedElement == marker.element;
-    final uploadState = widget.uploadQueue[marker.element];
-
-    return ScaleTransition(
-      scale: animation,
-      alignment: Alignment.bottomCenter,
-      filterQuality: FilterQuality.low,
-      child: OsmElementMarker(
-        onTap: () => uploadState == null ? widget.onOsmElementTap?.call(marker.element) : null,
-        active: isActive,
-        icon: marker.element.icon,
-        label: marker.element.elementLabel(appLocale),
-        uploadState: uploadState,
-      ),
-    );
-  }
-
-  AnimatedMarker _createMinimizedMarker(MapFeatureRepresentation element) {
-    return AnimatedMarker(
-      // use geo element as key, because osm element equality changes whenever its tags or version change
-      // while geo elements only compare the OSM element type and id
-      key: ValueKey(element),
-      point: element.geometry.center,
-      size: const Size.fromRadius(4),
-      animateInCurve: Curves.easeIn,
-      animateOutCurve: Curves.easeOut,
-      animateInDuration: const Duration(milliseconds: 300),
-      animateOutDuration: const Duration(milliseconds: 300),
-      // supply id as seed so we get the same delay for both marker types
-      animateOutDelay: _getRandomDelay(element.id),
-      builder: _minimizedMarkerBuilder,
-    );
-  }
-
-  Widget _minimizedMarkerBuilder(BuildContext context, Animation<double> animation, _) {
-    return FadeTransition(
-      opacity: animation,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: Colors.white,
-          shape: BoxShape.circle,
-          border: Border.all(
-            width: 1,
-            color: Theme.of(context).colorScheme.shadow.withValues(alpha: 0.26),
+          );
+        },
+        child: SizedBox(
+          width: 260,
+          height: 60,
+          child: Observer(
+            builder: (context) {
+              return OsmElementMarker(
+                onTap: () => item.uploadState == null
+                  ? item.onTap?.call(item)
+                  : null,
+                active: item.active,
+                icon: item.icon,
+                label: item.elementLabel(appLocale),
+                uploadState: item.uploadState,
+              );
+            },
           ),
         ),
       ),
     );
   }
-}
-
-class _OsmElementMarker extends AnimatedMarker {
-  final MapFeatureRepresentation element;
-
-  _OsmElementMarker({
-    required this.element,
-    required super.builder,
-    super.animateInDelay,
-  }) : super(
-         // use ElementIdentifier as key
-         // its equality doesn't change when its tags or version changes
-         key: ValueKey(element),
-         point: element.geometry.center,
-         size: const Size(260, 60),
-         anchor: Alignment.bottomCenter,
-         animateInCurve: Curves.elasticOut,
-         animateOutCurve: Curves.easeOutBack,
-         animateOutDuration: const Duration(milliseconds: 300),
-       );
-}
-
-class _ClusterLeafs extends ClusterDataBase {
-  final List<MapFeatureRepresentation> elements;
-
-  _ClusterLeafs(this.elements);
 
   @override
-  _ClusterLeafs combine(_ClusterLeafs other) {
-    return _ClusterLeafs(elements + other.elements);
+  bool isItemInViewport(item) {
+    // TODO: implement isItemInViewport
+    return true;
+  }
+
+  // Duration _getRandomDelay([int? seed]) {
+  //   if (widget.durationOffsetRange.inMicroseconds == 0) {
+  //     return Duration.zero;
+  //   }
+  //   final randomTimeOffset = Random(seed).nextInt(widget.durationOffsetRange.inMicroseconds);
+  //   return Duration(microseconds: randomTimeOffset);
+  // }
+}
+
+
+
+
+// think about delay differently
+
+// add a queue to which each new element is added and randomly remove them from the queue and add them to the map
+// or directly delay and add to map (only problem is an early removal)
+
+// directly Future.delayed().then(removeFromMapCollection + addToMap) <- store each future inside a map collection in case it got removed before it got added
+
+
+// delay has to be implemented in the add/remove together with curves functions via Interval because I need to update the duration
+
+
+abstract class AddRemovalAnimationBase<P extends StatefulWidget, T> extends State<P> with TickerProviderStateMixin {
+  Widget itemBuilder(BuildContext context, T item, Animation<double> animation);
+
+  final _items = <T, AnimationController?>{};
+
+  static const _kAlwaysStopped = AlwaysStoppedAnimation<double>(1);
+
+  Iterable<Widget> getChildren(BuildContext context) {
+    return _items.entries.map((item) => itemBuilder(
+        context,
+        item.key,
+        item.value ?? _kAlwaysStopped,
+      ),
+    );
+  }
+
+  /// doc
+  ///
+  ///
+  ///
+  void add(T item, {
+    Duration duration = Duration.zero,
+  }) {
+    if (isItemInViewport(item)) {
+      final AnimationController? controller;
+      if (duration != Duration.zero) {
+        controller = AnimationController(
+          duration: duration,
+          vsync: this,
+        );
+        controller.forward().then((_) {
+          controller!.dispose();
+          _items[item] = null;
+        });
+      }
+      else {
+        controller = null;
+      }
+      setState(() {
+        _items[item] = controller;
+      });
+    }
+    else {
+      _items[item] = null;
+    }
+  }
+
+  /// doc
+  ///
+  ///
+  ///
+  void remove(T item, {
+    Duration duration = Duration.zero,
+  }) {
+    if (isItemInViewport(item)) {
+      if (duration != Duration.zero) {
+        final controller = _items[item] ?? AnimationController(
+          duration: duration,
+          value: 1.0,
+          vsync: this,
+        );
+        controller.reverse().then((_) {
+          controller.dispose();
+          setState(() {
+            _items.remove(item);
+          });
+        });
+        setState(() {
+          _items[item] = controller;
+        });
+      }
+      else {
+        setState(() {
+          _items.remove(item);
+        });
+      }
+    }
+    else {
+      _items.remove(item);
+    }
+  }
+
+  bool isItemInViewport(T item);
+
+  @override
+  void dispose() {
+    for (final controller in _items.values) {
+      controller?.dispose();
+    }
+    super.dispose();
   }
 }
+
+typedef AnimatedMarkerLayerItemBuilder<T> = Widget Function(BuildContext context, T item, Animation<double> animation);


### PR DESCRIPTION
- move from clustering approach to collision based approach
- use existing marker layer
- reduce rebuilds by only rebuilding the markers that change
- have explicit add and remove widget functions instead of List difference detection (diff detection doesn't scale)
- reduces dependencies (removes animated_marker_layer + supercluster)