### PR TITLE
Reduce stop area loading cell size and zoom range (mitigates #293)

### DIFF
--- a/lib/api/app_worker/stop_area_handler.dart
+++ b/lib/api/app_worker/stop_area_handler.dart
@@ -45,7 +45,8 @@ mixin StopAreaHandler<M> on ServiceWorker<M> {
   /// The cell size in degrees.
   /// Some reference values can be found here: https://en.wikipedia.org/wiki/Decimal_degrees
 
-  final double _cellSize = 0.1;
+  // This has been reduced due to long loading times in urban areas, see: https://github.com/OPENER-next/OpenStop/issues/293
+  final double _cellSize = 0.02;
 
   /// A MultiStream that returns the number of currently loading cells on initial subscription.
   ///

--- a/lib/view_models/home_view_model.dart
+++ b/lib/view_models/home_view_model.dart
@@ -115,7 +115,7 @@ class HomeViewModel extends ViewModel with MakeTickerProvider, PromptMediator, N
   /// The query results can be accessed via the specific "stop areas" property.
 
   Future<void> loadStopAreas() async {
-    if (mapController.camera.zoom > 11) {
+    if (mapController.camera.zoom > 14) {
       return _appWorker.queryStopAreas(mapController.camera.visibleBounds);
     }
   }


### PR DESCRIPTION
## Technical changes
Reduces the area size in which stop areas are queried via Overpass. If quickly panning over the map the amount of requests to the overpass server is increased but the workload of the individual requests is reduced. In addition to that the zoom step at which stop areas are loaded was adjusted to the new cell size.

The cell size was chosen to get a response in a reasonable amount of time (~ 5sec) for bigger cities like Barcelona or Berlin.

## UX changes
Users now have to zoom in more closely in order to trigger the stop area loading. Additionally they will see the magnifier animation more frequently but for shorter periods of time as the response time is decreased.