### PR TITLE
Add duration stop watch

### DIFF
--- a/assets/question_catalog/definition.json
+++ b/assets/question_catalog/definition.json
@@ -3064,13 +3064,14 @@
       "answer": {
          "type": "Duration",
          "input": {
-            "max": 2,
+            "max": 180,
             "hours": {
                "display": false,
                "return": true
             },
             "minutes": {
-               "step": 1
+               "display": false,
+               "return": true
             },
             "seconds": {
                "step": 1

--- a/assets/question_catalog/locales/de.arb
+++ b/assets/question_catalog/locales/de.arb
@@ -436,7 +436,7 @@
   "@stairsHandrailName": {},
   "stairsHandrailText": "Hat die Treppe einen Handlauf?",
   "@stairsHandrailText": {},
-  "escalatorDurationName": "Rolltreppen-Fahrtdauer",
+  "escalatorDurationName": "Fahrtdauer",
   "@escalatorDurationName": {},
   "escalatorDurationText": "Wie lange dauert die Fahrt mit der Rolltreppe bzw. dem Laufband?",
   "@escalatorDurationText": {},

--- a/assets/question_catalog/locales/en.arb
+++ b/assets/question_catalog/locales/en.arb
@@ -444,7 +444,7 @@
   "@stairsHandrailName": {},
   "stairsHandrailText": "Do the stairs have a handrail?",
   "@stairsHandrailText": {},
-  "escalatorDurationName": "Escalator ride duration",
+  "escalatorDurationName": "Ride duration",
   "@escalatorDurationName": {},
   "escalatorDurationText": "How long does the escalator/moving sidewalk ride take?",
   "@escalatorDurationText": {},

--- a/lib/widgets/question_inputs/duration_input.dart
+++ b/lib/widgets/question_inputs/duration_input.dart
@@ -54,24 +54,55 @@ class DurationInput extends QuestionInputWidget<DurationAnswerDefinition, Durati
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 150,
-      child: Row(
-        children: _intersperse(
-          _children(context).map(
-            (child) => Flexible(child: child),
+    return Column(
+      children: [
+        SizedBox(
+          height: 130,
+          child: Row(
+            children: _intersperse(
+              _timeScrollerWidgets().map(
+                (child) => Flexible(child: child),
+              ),
+              Text(':',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+            ).toList(),
           ),
-          const VerticalDivider(color: Colors.transparent),
-        ).toList(),
-      ),
+        ),
+        Row(
+          children: _timeLabels(context)
+            .map<Widget>((label) => Expanded(
+              child: Text(label,
+                textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ),
+            )
+            .toList(),
+        ),
+      ],
     );
   }
 
-  Iterable<Widget> _children(BuildContext context) sync* {
+  Iterable<String> _timeLabels(BuildContext context) sync* {
     final appLocale = AppLocalizations.of(context)!;
     if (definition.input.days.display) {
+      yield appLocale.durationInputDaysLabel;
+    }
+    if (definition.input.hours.display) {
+      yield appLocale.durationInputHoursLabel;
+    }
+    if (definition.input.minutes.display) {
+      yield appLocale.durationInputMinutesLabel;
+    }
+    if (definition.input.seconds.display) {
+      yield appLocale.durationInputSecondsLabel;
+    }
+  }
+
+  Iterable<Widget> _timeScrollerWidgets() sync* {
+    if (definition.input.days.display) {
       yield TimeScroller(
-        name: appLocale.durationInputDaysLabel,
         step: definition.input.days.step,
         limit: _maxDays,
         value: _remainingDays,
@@ -80,7 +111,6 @@ class DurationInput extends QuestionInputWidget<DurationAnswerDefinition, Durati
     }
     if (definition.input.hours.display) {
       yield TimeScroller(
-        name: appLocale.durationInputHoursLabel,
         step: definition.input.hours.step,
         limit: _maxHours,
         value: _remainingHours,
@@ -89,7 +119,6 @@ class DurationInput extends QuestionInputWidget<DurationAnswerDefinition, Durati
     }
     if (definition.input.minutes.display) {
       yield TimeScroller(
-        name: appLocale.durationInputMinutesLabel,
         step: definition.input.minutes.step,
         limit: _maxMinutes,
         value: _remainingMinutes,
@@ -98,7 +127,6 @@ class DurationInput extends QuestionInputWidget<DurationAnswerDefinition, Durati
     }
     if (definition.input.seconds.display) {
       yield TimeScroller(
-        name: appLocale.durationInputSecondsLabel,
         step: definition.input.seconds.step,
         limit: _maxSeconds,
         value: _remainingSeconds,
@@ -143,8 +171,6 @@ class DurationInput extends QuestionInputWidget<DurationAnswerDefinition, Durati
 
 
 class TimeScroller extends StatefulWidget {
-  final String name;
-
   final int step;
 
   final int limit;
@@ -154,7 +180,6 @@ class TimeScroller extends StatefulWidget {
   final void Function(int duration) onChange;
 
   const TimeScroller({
-    required this.name,
     required this.step,
     required this.limit,
     required this.onChange,
@@ -186,67 +211,49 @@ class _TimeScrollerState extends State<TimeScroller> {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        Container(
-          margin: const EdgeInsets.only(top: 6.0),
-          foregroundDecoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                Theme.of(context).colorScheme.surface,
-                Theme.of(context).colorScheme.surface.withOpacity(0.0),
-                Theme.of(context).colorScheme.surface.withOpacity(0.0),
-                Theme.of(context).colorScheme.surface
-              ],
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              stops: const [0.07, 0.2, 0.8, 0.93],
-            ),
-            border: Border.all(color: Theme.of(context).colorScheme.primary),
-            borderRadius: const BorderRadius.all(Radius.circular(8.0)),
-          ),
-          child: ListWheelScrollView.useDelegate(
-            itemExtent: 30,
-            controller: _scrollController,
-            physics: const FixedExtentScrollPhysics(),
-            onSelectedItemChanged: (index) => widget.onChange(_indexToValue(index)),
-            childDelegate: ListWheelChildBuilderDelegate(
-              builder: (BuildContext context, int index) {
-                final value = _indexToValue(index);
-                // safety check required because selected item cannot be retrieved on initial build
-                final isActive = index == (_scrollController.position.hasContentDimensions
-                  ? _scrollController.selectedItem
-                  : _scrollController.initialItem
-                );
-                return Center(
-                  child: AnimatedOpacity(
-                    opacity: isActive ? 1 : 0.3,
-                    duration: const Duration(milliseconds: 200),
-                    child: AnimatedScale(
-                      scale: isActive ? 1 : 0.7,
-                      duration: const Duration(milliseconds: 200),
-                      child: Text(
-                        value.toString().padLeft(2, '0'),
-                        style: Theme.of(context).textTheme.headlineSmall
-                      ),
-                    ),
-                  ),
-                );
-              }
-            ),
-          ),
+    return DecoratedBox(
+      position: DecorationPosition.foreground,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Theme.of(context).colorScheme.surface,
+            Theme.of(context).colorScheme.surface.withOpacity(0.0),
+            Theme.of(context).colorScheme.surface.withOpacity(0.0),
+            Theme.of(context).colorScheme.surface
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          stops: const [0.07, 0.2, 0.8, 0.93],
         ),
-        Positioned(
-          left: 8,
-          child: Container(
-            color: Theme.of(context).colorScheme.surface,
-            padding: const EdgeInsets.symmetric(horizontal: 4.0),
-            child: Text(widget.name,
-              style: Theme.of(context).textTheme.bodySmall
-            )
-          ),
-        )
-      ]
+      ),
+      child: ListWheelScrollView.useDelegate(
+        itemExtent: 30,
+        controller: _scrollController,
+        physics: const FixedExtentScrollPhysics(),
+        onSelectedItemChanged: (index) => widget.onChange(_indexToValue(index)),
+        childDelegate: ListWheelChildBuilderDelegate(
+          builder: (BuildContext context, int index) {
+            final value = _indexToValue(index);
+            // safety check required because selected item cannot be retrieved on initial build
+            final isActive = index == (_scrollController.position.hasContentDimensions
+              ? _scrollController.selectedItem
+              : _scrollController.initialItem
+            );
+            return AnimatedOpacity(
+              opacity: isActive ? 1 : 0.3,
+              duration: const Duration(milliseconds: 200),
+              child: AnimatedScale(
+                scale: isActive ? 1 : 0.7,
+                duration: const Duration(milliseconds: 200),
+                child: Text(
+                  value.toString().padLeft(2, '0'),
+                  style: Theme.of(context).textTheme.headlineSmall
+                ),
+              ),
+            );
+          }
+        ),
+      ),
     );
   }
 


### PR DESCRIPTION
Closes #130

![Screenshot_1733391047](https://github.com/user-attachments/assets/1cf60447-9d11-4e20-ac5b-06c54bf35970)

Initially it was designed to work with minutes as well (see screenshot).
However the stop watch button is mainly used in scenarios with short time periods (up to 2 minutes) so it was simplified to work for seconds only.

![Screenshot_1733221765](https://github.com/user-attachments/assets/4d2c0eff-724f-4908-9acc-ceda6198790f)

Also contains a slight redesign of the general duration input.

![Screenshot_1733219581](https://github.com/user-attachments/assets/c11829a4-7a0a-4780-89e5-9d778ba5ae51)