### PR TITLE
Fix typo in crossingSignalsDescription

### DIFF
--- a/assets/question_catalog/locales/en.arb
+++ b/assets/question_catalog/locales/en.arb
@@ -454,7 +454,7 @@
   "@crossingSignalsName": {},
   "crossingSignalsText": "Are there pedestrian lights at this crossing?",
   "@crossingSignalsText": {},
-  "crossingSignalsDescription": "Indicates whether a crossing is controlled by a pedstrian light.",
+  "crossingSignalsDescription": "Indicates whether a crossing is controlled by a pedestrian light.",
   "@crossingSignalsDescription": {},
   "crossingMarkingsName": "Crossing markings",
   "@crossingMarkingsName": {},


### PR DESCRIPTION
Just a 1-char typo.